### PR TITLE
Don't run tests in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,3 @@ RUN apt-get update \
        texlive-xetex \
   && apt-get autoremove \
   && apt-get clean
-RUN curl -LO https://raw.githubusercontent.com/sphinx-doc/sphinx/master/test-reqs.txt
-RUN virtualenv -p python3.4 /python3.4 \
-  && /python3.4/bin/pip install -r test-reqs.txt
-
-RUN mkdir /repos /sphinx
-WORKDIR /sphinx
-CMD git clone /repos /sphinx \
-  && /python3.4/bin/pip install -U -r test-reqs.txt \
-  && make test PYTHON=/python3.4/bin/python


### PR DESCRIPTION
This container is only used for testing with Circle CI, which has its own way of specifying installation steps. In addition, not only is this currently broken due to the recent `requirements.txt` -> `setup.py`
changes on `master`, but this will break if/when the dependencies of `stable` differ from `master`.
    
Given that installing dependencies this way is both broken and unnecessary, we can and should stop doing it.
