### PR TITLE
Install "docs" extra requirement(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 
 # Install test dependencies
 RUN virtualenv -p python3.6 /python3.6 \
-  && /python3.6/bin/pip install "Sphinx[test,websupport]" \
+  && /python3.6/bin/pip install "Sphinx[test]" \
   && /python3.6/bin/pip uninstall -y Sphinx
 
 RUN mkdir /repos /sphinx


### PR DESCRIPTION
"websupport" is not in Sphinx' `extras_require`.

Ref: https://github.com/sphinx-doc/sphinx/pull/7249

Should probably get removed instead: https://github.com/sphinx-doc/sphinx/pull/7249#issuecomment-594608663