### PR TITLE
Add tex-gyre dependency for Sphinx 4.0.0 release testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
        texlive-latex-recommended \
        texlive-latex-extra \
        texlive-fonts-recommended \
+       tex-gyre \
        texlive-fonts-extra \
        texlive-luatex \
        texlive-xetex \


### PR DESCRIPTION
Relates https://github.com/sphinx-doc/sphinx/pull/8716

TeX Gyre provides clones of the "known-as-Adobe fonts in TeX" which have better support for the LaTeX font system, in particular relative to so-called TS1 text companion encodings compared to old latex package "times" which comes with the latex base system as part of the required files, but is not maintained anymore.

TeX Gyre also provides otf fonts, they are packaged on Ubuntu in [fonts-texgyre](https://packages.ubuntu.com/bionic/fonts-texgyre) but we currently use GNU FreeFont with xelatex and lualatex so we currently don't need them.